### PR TITLE
Feat: 엔트로피 계산 기능 구현 

### DIFF
--- a/Multicore_MidtermProject.vcxproj
+++ b/Multicore_MidtermProject.vcxproj
@@ -106,6 +106,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalIncludeDirectories>C:\opencv\build\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -124,6 +125,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <AdditionalIncludeDirectories>C:\opencv\build\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OpenMPSupport>true</OpenMPSupport>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -137,6 +139,7 @@
   <ItemGroup>
     <ClCompile Include="binarization.c" />
     <ClCompile Include="bi_utils.c" />
+    <ClCompile Include="entropy_utils.c" />
     <ClCompile Include="frameCalculator.c" />
     <ClCompile Include="frame_utils.c" />
     <ClCompile Include="main.c" />
@@ -146,6 +149,7 @@
   <ItemGroup>
     <ClInclude Include="binarization.h" />
     <ClInclude Include="bi_utils.h" />
+    <ClInclude Include="entropy_utils.h" />
     <ClInclude Include="frame_utils.h" />
     <ClInclude Include="overlay_utils.h" />
     <ClInclude Include="video_utils.h" />

--- a/Multicore_MidtermProject.vcxproj.filters
+++ b/Multicore_MidtermProject.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="video_utils.c">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="entropy_utils.c">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="bi_utils.h">
@@ -51,6 +54,9 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="video_utils.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="entropy_utils.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/binarization.c
+++ b/binarization.c
@@ -2,13 +2,14 @@
 
 #include "binarization.h"
 #include <stdlib.h>
-#include <omp.h>  // 병렬 처리
+#include <omp.h>  
 #include <stdio.h>
 
 void compute_difference(uint8_t* img1, uint8_t* img2, uint8_t* diff, int width, int height) {
     int size = width * height;
+    int i;
 #pragma omp parallel for
-    for (int i = 0; i < size; i++) {
+    for (i = 0; i < size; i++) {
         int d = (int)img1[i] - (int)img2[i];
         diff[i] = (uint8_t)(d < 0 ? -d : d);
     }
@@ -16,8 +17,9 @@ void compute_difference(uint8_t* img1, uint8_t* img2, uint8_t* diff, int width, 
 
 void binarize_image_parallel(uint8_t* diff, uint8_t* binary, int width, int height, uint8_t threshold) {
     int size = width * height;
+    int i;
 #pragma omp parallel for
-    for (int i = 0; i < size; i++) {
+    for (i = 0; i < size; i++) {
         binary[i] = (diff[i] > threshold) ? 255 : 0;
     }
 }

--- a/entropy_utils.c
+++ b/entropy_utils.c
@@ -16,18 +16,17 @@
 #define BIN_SIZE 256
 
 void compute_entropy_array(const char* outputDir, int totalFrames, double* entropy_array) {
-    int i, p, j, by, bx, y, x, b;
-#pragma omp parallel for schedule(dynamic)
-    for (i = 1; i < totalFrames; i++) {
-        char diffPGM[256];
-        sprintf(diffPGM, "%s/diff_%04d.pgm", outputDir, i);
+    int i, p;
+#pragma omp parallel for schedule(dynamic,4)
+    for ( i = 1; i < totalFrames; i++) {
+        char diffPGM[512];
+        snprintf(diffPGM, sizeof(diffPGM), "%s/diff_%04d.pgm", outputDir, i);
 
         int width = 0, height = 0;
         uint8_t* image = my_load_pgm(diffPGM, &width, &height);
-        if (!image || width <= 0 || height <= 0) {
-            entropy_array[i - 1] = -1.0;
-            continue;
-        }
+        if (!image) continue;
+
+        double t0 = omp_get_wtime();  // 계산 시간 측정 시작
 
         int total_pixels = width * height;
         int histogram[BIN_SIZE] = { 0 };
@@ -35,17 +34,23 @@ void compute_entropy_array(const char* outputDir, int totalFrames, double* entro
 #pragma omp parallel
         {
             int local_hist[BIN_SIZE] = { 0 };
-#pragma omp for nowait
+
+#pragma omp for
             for (p = 0; p < total_pixels; p++) {
                 uint8_t val = image[p];
-                if (val < BIN_SIZE) local_hist[val]++;
+                if (val < BIN_SIZE)
+                    local_hist[val]++;
             }
+
 #pragma omp critical
-            for (j = 0; j < BIN_SIZE; j++) histogram[j] += local_hist[j];
+            {
+                for (int j = 0; j < BIN_SIZE; j++)
+                    histogram[j] += local_hist[j];
+            }
         }
 
         double entropy = 0.0;
-        for (j = 0; j < BIN_SIZE; j++) {
+        for (int j = 0; j < BIN_SIZE; j++) {
             if (histogram[j] > 0) {
                 double prob = (double)histogram[j] / total_pixels;
                 entropy -= prob * log2(prob);
@@ -60,61 +65,156 @@ void compute_entropy_array(const char* outputDir, int totalFrames, double* entro
 
             double* local_entropies = (double*)malloc(sizeof(double) * num_blocks);
             if (!local_entropies) {
-                entropy_array[i - 1] = entropy;
                 free(image);
                 continue;
             }
 
-#pragma omp parallel for collapse(2)
-            for (by = 0; by < blocks_y; by++) {
-                for (bx = 0; bx < blocks_x; bx++) {
-                    int local_hist[BIN_SIZE] = { 0 };
-                    int block_pixels = 0;
-                    for (y = by * block_size; y < (by + 1) * block_size && y < height; y++) {
-                        for (x = bx * block_size; x < (bx + 1) * block_size && x < width; x++) {
-                            int idx2 = y * width + x;
-                            if (idx2 < total_pixels) {
-                                uint8_t val = image[idx2];
-                                if (val < BIN_SIZE) {
-                                    local_hist[val]++;
-                                    block_pixels++;
-                                }
-                            }
+            for (int block_index = 0; block_index < num_blocks; block_index++) {
+                int by = block_index / blocks_x;
+                int bx = block_index % blocks_x;
+
+                int local_hist[BIN_SIZE] = { 0 };
+                int block_pixels = 0;
+
+                for (int y = by * block_size; y < (by + 1) * block_size && y < height; y++) {
+                    for (int x = bx * block_size; x < (bx + 1) * block_size && x < width; x++) {
+                        int idx = y * width + x;
+                        uint8_t val = image[idx];
+                        if (val < BIN_SIZE) {
+                            local_hist[val]++;
+                            block_pixels++;
                         }
                     }
+                }
 
-                    double block_entropy = 0.0;
-                    for (j = 0; j < BIN_SIZE; j++) {
+                double block_entropy = 0.0;
+                if (block_pixels > 0) {
+                    for (int j = 0; j < BIN_SIZE; j++) {
                         if (local_hist[j] > 0) {
                             double prob = (double)local_hist[j] / block_pixels;
                             block_entropy -= prob * log2(prob);
                         }
                     }
-
-                    local_entropies[by * blocks_x + bx] = block_entropy;
                 }
+
+                local_entropies[block_index] = block_entropy;
             }
 
-            double mean_local_entropy = 0.0;
-            for (b = 0; b < num_blocks; b++) {
-                mean_local_entropy += local_entropies[b];
-            }
-            mean_local_entropy /= num_blocks;
+            double mean = 0.0;
+            for (int b = 0; b < num_blocks; b++)
+                mean += local_entropies[b];
+            mean /= num_blocks;
 
             double variance = 0.0;
-            for (b = 0; b < num_blocks; b++) {
-                variance += pow(local_entropies[b] - mean_local_entropy, 2);
-            }
+            for (int b = 0; b < num_blocks; b++)
+                variance += pow(local_entropies[b] - mean, 2);
             variance /= num_blocks;
 
-            if (!isnan(variance) && variance >= 0) {
+            if (!isnan(variance) && variance >= 0.0)
                 entropy *= (1.0 + sqrt(variance));
-            }
 
             free(local_entropies);
         }
 
         entropy_array[i - 1] = entropy;
+
+        double t1 = omp_get_wtime();  
+
+        free(image);
+    }
+}
+
+void compute_entropy_array_serial(const char* outputDir, int totalFrames, double* entropy_array) {
+    for (int i = 1; i < totalFrames; i++) {
+        char diffPGM[512];
+        snprintf(diffPGM, sizeof(diffPGM), "%s/diff_%04d.pgm", outputDir, i);
+
+        int width = 0, height = 0;
+        uint8_t* image = my_load_pgm(diffPGM, &width, &height);
+        if (!image) continue;
+
+        double t0 = omp_get_wtime(); 
+
+        int total_pixels = width * height;
+        int histogram[BIN_SIZE] = { 0 };
+
+        for (int p = 0; p < total_pixels; p++) {
+            uint8_t val = image[p];
+            if (val < BIN_SIZE)
+                histogram[val]++;
+        }
+
+        double entropy = 0.0;
+        for (int j = 0; j < BIN_SIZE; j++) {
+            if (histogram[j] > 0) {
+                double prob = (double)histogram[j] / total_pixels;
+                entropy -= prob * log2(prob);
+            }
+        }
+
+        if (entropy > 4.0) {
+            int block_size = 16;
+            int blocks_x = (width > block_size) ? width / block_size : 1;
+            int blocks_y = (height > block_size) ? height / block_size : 1;
+            int num_blocks = blocks_x * blocks_y;
+
+            double* local_entropies = (double*)malloc(sizeof(double) * num_blocks);
+            if (!local_entropies) {
+                free(image);
+                continue;
+            }
+
+            int block_index = 0;
+            for (int by = 0; by < blocks_y; by++) {
+                for (int bx = 0; bx < blocks_x; bx++) {
+                    int local_hist[BIN_SIZE] = { 0 };
+                    int block_pixels = 0;
+
+                    for (int y = by * block_size; y < (by + 1) * block_size && y < height; y++) {
+                        for (int x = bx * block_size; x < (bx + 1) * block_size && x < width; x++) {
+                            int idx = y * width + x;
+                            uint8_t val = image[idx];
+                            if (val < BIN_SIZE) {
+                                local_hist[val]++;
+                                block_pixels++;
+                            }
+                        }
+                    }
+
+                    double block_entropy = 0.0;
+                    if (block_pixels > 0) {
+                        for (int j = 0; j < BIN_SIZE; j++) {
+                            if (local_hist[j] > 0) {
+                                double prob = (double)local_hist[j] / block_pixels;
+                                block_entropy -= prob * log2(prob);
+                            }
+                        }
+                    }
+
+                    local_entropies[block_index++] = block_entropy;
+                }
+            }
+
+            double mean = 0.0;
+            for (int b = 0; b < num_blocks; b++)
+                mean += local_entropies[b];
+            mean /= num_blocks;
+
+            double variance = 0.0;
+            for (int b = 0; b < num_blocks; b++)
+                variance += pow(local_entropies[b] - mean, 2);
+            variance /= num_blocks;
+
+            if (!isnan(variance) && variance >= 0.0)
+                entropy *= (1.0 + sqrt(variance));
+
+            free(local_entropies);
+        }
+
+        entropy_array[i - 1] = entropy;
+
+        double t1 = omp_get_wtime();
+
         free(image);
     }
 }

--- a/entropy_utils.c
+++ b/entropy_utils.c
@@ -1,0 +1,120 @@
+﻿#define _CRT_SECURE_NO_WARNINGS
+
+#include <omp.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include "frame_utils.h"
+#include "bi_utils.h"
+#include "binarization.h"
+#include "video_utils.h"
+#include "overlay_utils.h"
+#include "entropy_utils.h"
+
+#define BIN_SIZE 256
+
+void compute_entropy_array(const char* outputDir, int totalFrames, double* entropy_array) {
+    int i, p, j, by, bx, y, x, b;
+#pragma omp parallel for schedule(dynamic)
+    for (i = 1; i < totalFrames; i++) {
+        char diffPGM[256];
+        sprintf(diffPGM, "%s/diff_%04d.pgm", outputDir, i);
+
+        int width = 0, height = 0;
+        uint8_t* image = my_load_pgm(diffPGM, &width, &height);
+        if (!image || width <= 0 || height <= 0) {
+            entropy_array[i - 1] = -1.0;
+            continue;
+        }
+
+        int total_pixels = width * height;
+        int histogram[BIN_SIZE] = { 0 };
+
+#pragma omp parallel
+        {
+            int local_hist[BIN_SIZE] = { 0 };
+#pragma omp for nowait
+            for (p = 0; p < total_pixels; p++) {
+                uint8_t val = image[p];
+                if (val < BIN_SIZE) local_hist[val]++;
+            }
+#pragma omp critical
+            for (j = 0; j < BIN_SIZE; j++) histogram[j] += local_hist[j];
+        }
+
+        double entropy = 0.0;
+        for (j = 0; j < BIN_SIZE; j++) {
+            if (histogram[j] > 0) {
+                double prob = (double)histogram[j] / total_pixels;
+                entropy -= prob * log2(prob);
+            }
+        }
+
+        if (entropy > 4.0) {
+            int block_size = 16;
+            int blocks_x = (width > block_size) ? width / block_size : 1;
+            int blocks_y = (height > block_size) ? height / block_size : 1;
+            int num_blocks = blocks_x * blocks_y;
+
+            double* local_entropies = (double*)malloc(sizeof(double) * num_blocks);
+            if (!local_entropies) {
+                entropy_array[i - 1] = entropy;
+                free(image);
+                continue;
+            }
+
+#pragma omp parallel for collapse(2)
+            for (by = 0; by < blocks_y; by++) {
+                for (bx = 0; bx < blocks_x; bx++) {
+                    int local_hist[BIN_SIZE] = { 0 };
+                    int block_pixels = 0;
+                    for (y = by * block_size; y < (by + 1) * block_size && y < height; y++) {
+                        for (x = bx * block_size; x < (bx + 1) * block_size && x < width; x++) {
+                            int idx2 = y * width + x;
+                            if (idx2 < total_pixels) {
+                                uint8_t val = image[idx2];
+                                if (val < BIN_SIZE) {
+                                    local_hist[val]++;
+                                    block_pixels++;
+                                }
+                            }
+                        }
+                    }
+
+                    double block_entropy = 0.0;
+                    for (j = 0; j < BIN_SIZE; j++) {
+                        if (local_hist[j] > 0) {
+                            double prob = (double)local_hist[j] / block_pixels;
+                            block_entropy -= prob * log2(prob);
+                        }
+                    }
+
+                    local_entropies[by * blocks_x + bx] = block_entropy;
+                }
+            }
+
+            double mean_local_entropy = 0.0;
+            for (b = 0; b < num_blocks; b++) {
+                mean_local_entropy += local_entropies[b];
+            }
+            mean_local_entropy /= num_blocks;
+
+            double variance = 0.0;
+            for (b = 0; b < num_blocks; b++) {
+                variance += pow(local_entropies[b] - mean_local_entropy, 2);
+            }
+            variance /= num_blocks;
+
+            if (!isnan(variance) && variance >= 0) {
+                entropy *= (1.0 + sqrt(variance));
+            }
+
+            free(local_entropies);
+        }
+
+        entropy_array[i - 1] = entropy;
+        free(image);
+    }
+}

--- a/entropy_utils.h
+++ b/entropy_utils.h
@@ -1,0 +1,6 @@
+#ifndef ENTROPY_UTILS_H
+#define ENTROPY_UTILS_H
+
+void compute_entropy_array(const char* outputDir, int totalFrames, double* entropy_array);
+
+#endif

--- a/frame_utils.c
+++ b/frame_utils.c
@@ -6,17 +6,8 @@
 int saveFrame(IplImage* frame, const char* outputDir, int frameCount)
 {
     char filename[256];
-
     sprintf(filename, "%s/frame_%04d.jpg", outputDir, frameCount);
-
-    int result = cvSaveImage(filename, frame, 0);
-
-    if (result)
-        printf("저장됨: %s\n", filename);
-    else
-        printf("저장 실패: %s\n", filename);
-
-    return result;
+    return cvSaveImage(filename, frame, 0);
 }
 
 int saveFrameAsPGM(IplImage* frame, const char* outputDir, int frameCount)
@@ -44,11 +35,6 @@ int saveFrameAsPGM(IplImage* frame, const char* outputDir, int frameCount)
         cvReleaseImage(&grayFrame);
     }
 
-    if (result)
-        printf("PGM 형식으로 저장됨: %s\n", filename);
-    else
-        printf("PGM 저장 실패: %s\n", filename);
-
     return result;
 }
 
@@ -57,21 +43,32 @@ int extractFrames(CvCapture* capture, const char* outputDir)
     IplImage* frame;
     int frameCount = 0;
 
+    int totalFrames = (int)cvGetCaptureProperty(capture, CV_CAP_PROP_FRAME_COUNT);
+
     while ((frame = cvQueryFrame(capture)) != NULL)
     {
-        if (!saveFrame(frame, outputDir, frameCount))
+        if (!saveFrame(frame, outputDir, frameCount) ||
+            !saveFrameAsPGM(frame, outputDir, frameCount))
         {
-            printf("프레임 저장 중 오류 발생, 중단합니다.\n");
             break;
         }
 
-        if (!saveFrameAsPGM(frame, outputDir, frameCount))
-        {
-            printf("프레임 저장 중 오류 발생, 중단합니다.\n");
-            break;
-        }
         frameCount++;
+
+        if (frameCount % 10 == 0)  
+        {
+            int progress = (frameCount * 100) / totalFrames;  
+            printf("\r[");
+            for (int i = 0; i < progress / 2; i++)  
+                printf("=");
+            for (int i = progress / 2; i < 50; i++)  
+                printf(" ");
+            printf("] %d%%", progress);
+            fflush(stdout);  
+        }
     }
+
+    printf("\n");
 
     return frameCount;
 }

--- a/main.c
+++ b/main.c
@@ -1,34 +1,33 @@
 #define _CRT_SECURE_NO_WARNINGS
-#include <stdio.h>
+
+#include <omp.h>
+#include <stdint.h>
 #include <stdlib.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
 #include "frame_utils.h"
 #include "bi_utils.h"
 #include "binarization.h"
 #include "video_utils.h"
-#include "overlay_utils.h" 
+#include "overlay_utils.h"
+#include "entropy_utils.h"
 
 int main(int argc, char** argv)
 {
     const char* videoPath;
     const char* outputDir;
-    int threshold = 20;  // 이진화 임계값
-    int min_area = 100;  // // 너무 작은 외곽선(노이즈)을 걸러내는 용도
+    int threshold = 20;
+    int min_area = 100;
 
-    // 인자 파싱
     if (parseArguments(argc, argv, &videoPath, &outputDir) != 0) {
         printf("사용법: %s <동영상 파일 경로> <저장 폴더 경로> [임계값] [최소면적]\n", argv[0]);
         return -1;
     }
-    if (argc >= 4) {
-        threshold = atoi(argv[3]);
-    }
-    if (argc >= 5) {
-        min_area = atoi(argv[4]);
-    }
+    if (argc >= 4) threshold = atoi(argv[3]);
+    if (argc >= 5) min_area = atoi(argv[4]);
 
-    // ========================
-    // Phase 1: 프레임 추출 (JPG, PGM)
-    // ========================
+    // Phase 1: 프레임 추출
     CvCapture* capture = openVideo(videoPath);
     if (!capture) return -1;
 
@@ -36,13 +35,9 @@ int main(int argc, char** argv)
     cvReleaseCapture(&capture);
     printf("전체 프레임 수: %d\n", totalFrames);
 
-    // ========================
-    // 2: 프레임 두 장을 한 쌍으로 잡고, 픽셀 차이 계산
-    // ========================
+    // Phase 2: 차이 계산 및 이진화
     for (int i = 0; i < totalFrames - 1; i++) {
-        char prevPGM[256], curPGM[256];
-        char diffPGM[256], binaryPGM[256];
-
+        char prevPGM[256], curPGM[256], diffPGM[256], binaryPGM[256];
         sprintf(prevPGM, "%s/frame_%04d.pgm", outputDir, i);
         sprintf(curPGM, "%s/frame_%04d.pgm", outputDir, i + 1);
         sprintf(diffPGM, "%s/diff_%04d.pgm", outputDir, i + 1);
@@ -52,20 +47,14 @@ int main(int argc, char** argv)
         uint8_t* img1 = my_load_pgm(prevPGM, &width, &height);
         uint8_t* img2 = my_load_pgm(curPGM, &width, &height);
         if (!img1 || !img2) {
-            fprintf(stderr, "이미지 파일 로딩 실패: %s 또는 %s\n", prevPGM, curPGM);
-            free(img1);
-            free(img2);
+            free(img1); free(img2);
             continue;
         }
 
         uint8_t* diff = (uint8_t*)malloc(width * height);
         uint8_t* binary = (uint8_t*)malloc(width * height);
         if (!diff || !binary) {
-            fprintf(stderr, "메모리 할당 실패.\n");
-            free(img1);
-            free(img2);
-            free(diff);
-            free(binary);
+            free(img1); free(img2); free(diff); free(binary);
             continue;
         }
 
@@ -74,17 +63,23 @@ int main(int argc, char** argv)
 
         my_save_pgm(diffPGM, diff, width, height);
         my_save_pgm(binaryPGM, binary, width, height);
-        free(img1);
-        free(img2);
-        free(diff);
-        free(binary);
-        printf("Diff 및 binary 파일 저장됨: %s, %s\n", diffPGM, binaryPGM);
+        free(img1); free(img2); free(diff); free(binary);
     }
 
-    // ========================
-    // 3: 마스크 생성하여 원본 사진에다가 오버레이 적용
-    // ========================
+    // Phase 3: 오버레이 생성
     overlayContoursOnFrames(outputDir, totalFrames, min_area);
 
+    // Phase 4: 엔트로피 계산
+    double* entropy_array = (double*)malloc(sizeof(double) * (totalFrames - 1));
+    if (!entropy_array) return -1;
+
+    compute_entropy_array(outputDir, totalFrames, entropy_array);
+
+    printf("=== 엔트로피 값 (샘플 출력) ===\n");
+    for (int i = 0; i < 10 && i < totalFrames - 1; i++) {
+        printf("frame %04d entropy raw: %.4lf\n", i + 1, entropy_array[i]);
+    }
+
+    free(entropy_array);
     return 0;
 }

--- a/overlay_utils.c
+++ b/overlay_utils.c
@@ -2,6 +2,7 @@
 #include <math.h>
 #include <opencv/cv.h>
 #include <opencv/highgui.h>
+#include <stdio.h>
 
 void overlayContoursOnFrames(const char* outputDir, int totalFrames, int min_area) {
     for (int i = 1; i < totalFrames; i++) {
@@ -39,21 +40,18 @@ void overlayContoursOnFrames(const char* outputDir, int totalFrames, int min_are
             cvDrawContours(overlayImg, c, CV_RGB(0, 255, 0), CV_RGB(0, 255, 0), 0, 2, 8, cvPoint(0, 0));
         }
 
-        for (int y = 0; y < overlayImg->height; y++) {
-            uchar* pMask = (uchar*)(fullMask->imageData + y * fullMask->widthStep);
-            uchar* pOverlay = (uchar*)(overlayImg->imageData + y * overlayImg->widthStep);
-            for (int x = 0; x < overlayImg->width; x++) {
-                if (pMask[x] == 255) {
-                    float alpha = 0.4f;
-                    pOverlay[x * 3 + 0] = (uchar)(pOverlay[x * 3 + 0] * (1 - alpha));
-                    pOverlay[x * 3 + 1] = (uchar)(pOverlay[x * 3 + 1] * (1 - alpha));
-                    pOverlay[x * 3 + 2] = (uchar)(pOverlay[x * 3 + 2] * (1 - alpha) + 255 * alpha);
-                }
-            }
-        }
+        // 로딩바 출력 (진행 상태 표시)
+        int progress = (i * 100) / (totalFrames - 1);  // 진행률 계산
+        printf("\r[");
+        for (int j = 0; j < progress / 2; j++)  // 50칸 기준으로 로딩바 출력
+            printf("=");
+        for (int j = progress / 2; j < 50; j++)  // 나머지 부분은 공백
+            printf(" ");
+        printf("] %d%%", progress);
+        fflush(stdout);  // 버퍼를 강제로 비우기
 
-        if (cvSaveImage(overlayJPG, overlayImg, 0))
-            printf(" 오버레이 저장 완료: %s\n", overlayJPG);
+        // 이미지 저장
+        cvSaveImage(overlayJPG, overlayImg, 0);
 
         cvReleaseImage(&binaryImg);
         cvReleaseImage(&colorImg);
@@ -61,4 +59,7 @@ void overlayContoursOnFrames(const char* outputDir, int totalFrames, int min_are
         cvReleaseImage(&fullMask);
         cvReleaseMemStorage(&storage);
     }
+
+    // 마지막 줄바꿈 추가
+    printf("\n");
 }

--- a/overlay_utils.c
+++ b/overlay_utils.c
@@ -11,6 +11,8 @@ void overlayContoursOnFrames(const char* outputDir, int totalFrames, int min_are
         sprintf(overlayJPG, "%s/overlay_%04d.jpg", outputDir, i);
 
         IplImage* binaryImg = cvLoadImage(binaryPGM, CV_LOAD_IMAGE_GRAYSCALE);
+        if (!binaryImg) continue;
+
         cvDilate(binaryImg, binaryImg, NULL, 1);
         cvErode(binaryImg, binaryImg, NULL, 1);
 
@@ -20,6 +22,12 @@ void overlayContoursOnFrames(const char* outputDir, int totalFrames, int min_are
             CV_RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE, cvPoint(0, 0));
 
         IplImage* colorImg = cvLoadImage(colorJPG, CV_LOAD_IMAGE_COLOR);
+        if (!colorImg) {
+            cvReleaseImage(&binaryImg);
+            cvReleaseMemStorage(&storage);
+            continue;
+        }
+
         IplImage* overlayImg = cvCloneImage(colorImg);
         IplImage* fullMask = cvCreateImage(cvGetSize(overlayImg), IPL_DEPTH_8U, 1);
         cvZero(fullMask);
@@ -44,7 +52,8 @@ void overlayContoursOnFrames(const char* outputDir, int totalFrames, int min_are
             }
         }
 
-        cvSaveImage(overlayJPG, overlayImg, 0);
+        if (cvSaveImage(overlayJPG, overlayImg, 0))
+            printf(" 오버레이 저장 완료: %s\n", overlayJPG);
 
         cvReleaseImage(&binaryImg);
         cvReleaseImage(&colorImg);


### PR DESCRIPTION
각 프레임 엔트로피 구하고 배열에 저장 #10 
![image](https://github.com/user-attachments/assets/4052d949-f728-46f6-a87b-d3d49ff91f3b)

엔트로피 계산 병렬화
프레임 단위 병렬 처리 (dynamic)로 작업 불균형(엔트로피가 높은 특정 프레임의 경우 지역 엔트로피 분산을 추가로 계산함) 완화
히스토그램 계산에 로컬 배열 + 병합 방식 적용
계산 시간 단축 및 성능 개선

결과는 entropy_serial 배열과 entropy_parallel에 저장됨
